### PR TITLE
fix: Parquet format arrays

### DIFF
--- a/parquet/read.go
+++ b/parquet/read.go
@@ -20,7 +20,7 @@ func (*Client) Read(f io.Reader, table *schema.Table, sourceName string, res cha
 		return err
 	}
 
-	s := makeSchema(table.Columns)
+	s := makeSchema(table.Name, table.Columns)
 	r, err := reader.NewParquetReader(newPQReader(buf.Bytes()), s, 2)
 	if err != nil {
 		return fmt.Errorf("can't create parquet reader: %w", err)

--- a/parquet/schema.go
+++ b/parquet/schema.go
@@ -32,7 +32,12 @@ func makeSchema(tableName string, cols schema.ColumnList) string {
 		case schema.TypeBool:
 			tag = append(tag, "type=BOOLEAN")
 		case schema.TypeIntArray:
-			tag = append(tag, "type=INT64", "repetitiontype=REPEATED")
+			tag = append(tag, "type=LIST", "repetitiontype=OPTIONAL")
+			subFields = []*pschema.JSONSchemaItemType{
+				{
+					Tag: "name=element, type=INT64, repetitiontype=OPTIONAL",
+				},
+			}
 		case schema.TypeStringArray, schema.TypeUUIDArray, schema.TypeCIDRArray, schema.TypeInetArray, schema.TypeMacAddrArray:
 			tag = append(tag, "type=LIST", "repetitiontype=OPTIONAL")
 			subFields = []*pschema.JSONSchemaItemType{

--- a/parquet/schema.go
+++ b/parquet/schema.go
@@ -27,7 +27,7 @@ func makeSchema(tableName string, cols schema.ColumnList) string {
 		case schema.TypeString /*schema.TypeUUID,*/, schema.TypeCIDR, schema.TypeInet, schema.TypeMacAddr:
 			tag = append(tag, "type=BYTE_ARRAY", "convertedtype=UTF8")
 		case schema.TypeUUID:
-			tag = append(tag, "type=BYTE_ARRAY", "convertedtype=UTF8", "logicaltype=UUID")
+			tag = append(tag, "type=BYTE_ARRAY", "convertedtype=UTF8") //, "logicaltype=UUID")
 			//tag = append(tag, "type=FIXED_LEN_BYTE_ARRAY", "length=16" /*"convertedtype=UTF8",*/, "logicaltype=UUID")
 		case schema.TypeFloat:
 			tag = append(tag, "type=DOUBLE")
@@ -50,7 +50,8 @@ func makeSchema(tableName string, cols schema.ColumnList) string {
 			tag = append(tag, "type=LIST", "repetitiontype=OPTIONAL")
 			subFields = []*pschema.JSONSchemaItemType{
 				{
-					Tag: "name=element, type=BYTE_ARRAY, convertedtype=UTF8, logicaltype=UUID, repetitiontype=OPTIONAL",
+					//Tag: "name=element, type=BYTE_ARRAY, convertedtype=UTF8, logicaltype=UUID, repetitiontype=OPTIONAL",
+					Tag: "name=element, type=BYTE_ARRAY, convertedtype=UTF8, repetitiontype=OPTIONAL",
 					//Tag: "name=element, type=FIXED_LEN_BYTE_ARRAY, length=16, logicaltype=UUID, repetitiontype=OPTIONAL",
 				},
 			}

--- a/parquet/schema.go
+++ b/parquet/schema.go
@@ -8,56 +8,73 @@ import (
 	pschema "github.com/xitongsys/parquet-go/schema"
 )
 
-func makeSchema(cols schema.ColumnList) string {
+func makeSchema(tableName string, cols schema.ColumnList) string {
 	s := pschema.JSONSchemaItemType{
+		//Tag: `name=` + tableName + `_root, repetitiontype=REQUIRED`,
 		Tag: `name=parquet_go_root, repetitiontype=REQUIRED`,
 	}
 
-	for i := range cols {
-		tag := `name=` + cols[i].Name
-		if opts := structOptsForColumn(cols[i]); len(opts) > 0 {
-			tag += ", " + strings.Join(opts, ", ")
+	for _, col := range cols {
+		var subFields []*pschema.JSONSchemaItemType
+
+		tag := []string{`name=` + col.Name}
+
+		switch col.Type {
+		case schema.TypeJSON:
+			tag = append(tag, "type=BYTE_ARRAY", "convertedtype=UTF8", "logicaltype=JSON")
+		case schema.TypeTimestamp:
+			tag = append(tag, "type=INT64", "convertedtype=TIMESTAMP_MILLIS")
+		case schema.TypeString /*schema.TypeUUID,*/, schema.TypeCIDR, schema.TypeInet, schema.TypeMacAddr:
+			tag = append(tag, "type=BYTE_ARRAY", "convertedtype=UTF8")
+		case schema.TypeUUID:
+			tag = append(tag, "type=BYTE_ARRAY", "convertedtype=UTF8", "logicaltype=UUID")
+			//tag = append(tag, "type=FIXED_LEN_BYTE_ARRAY", "length=16" /*"convertedtype=UTF8",*/, "logicaltype=UUID")
+		case schema.TypeFloat:
+			tag = append(tag, "type=DOUBLE")
+		case schema.TypeInt:
+			tag = append(tag, "type=INT64")
+		case schema.TypeByteArray:
+			tag = append(tag, "type=BYTE_ARRAY")
+		case schema.TypeBool:
+			tag = append(tag, "type=BOOLEAN")
+		case schema.TypeIntArray:
+			tag = append(tag, "type=INT64", "repetitiontype=REPEATED")
+		case schema.TypeStringArray /*schema.TypeUUIDArray,*/, schema.TypeCIDRArray, schema.TypeInetArray, schema.TypeMacAddrArray:
+			tag = append(tag, "type=LIST", "repetitiontype=OPTIONAL")
+			subFields = []*pschema.JSONSchemaItemType{
+				{
+					Tag: "name=element, type=BYTE_ARRAY, convertedtype=UTF8, repetitiontype=OPTIONAL",
+				},
+			}
+		case schema.TypeUUIDArray:
+			tag = append(tag, "type=LIST", "repetitiontype=OPTIONAL")
+			subFields = []*pschema.JSONSchemaItemType{
+				{
+					Tag: "name=element, type=BYTE_ARRAY, convertedtype=UTF8, logicaltype=UUID, repetitiontype=OPTIONAL",
+					//Tag: "name=element, type=FIXED_LEN_BYTE_ARRAY, length=16, logicaltype=UUID, repetitiontype=OPTIONAL",
+				},
+			}
+		default:
+			panic("unhandled type: " + col.Type.String())
 		}
-		s.Fields = append(s.Fields, &pschema.JSONSchemaItemType{Tag: tag})
+
+		switch col.Type {
+		case schema.TypeStringArray, schema.TypeIntArray, schema.TypeUUIDArray, schema.TypeCIDRArray, schema.TypeInetArray, schema.TypeMacAddrArray:
+			// no repetitiontype: handled above
+		default:
+			if col.CreationOptions.PrimaryKey || col.CreationOptions.IncrementalKey {
+				tag = append(tag, "repetitiontype=REQUIRED")
+			} else {
+				tag = append(tag, "repetitiontype=OPTIONAL")
+			}
+		}
+
+		s.Fields = append(s.Fields, &pschema.JSONSchemaItemType{
+			Tag:    strings.Join(tag, ", "),
+			Fields: subFields,
+		})
 	}
 
 	b, _ := json.Marshal(s)
 	return string(b)
-}
-
-func structOptsForColumn(col schema.Column) []string {
-	opts := []string{}
-
-	switch col.Type {
-	case schema.TypeJSON:
-		opts = append(opts, "type=BYTE_ARRAY", "convertedtype=UTF8")
-	case schema.TypeTimestamp:
-		opts = append(opts, "type=INT64", "convertedtype=TIMESTAMP_MILLIS")
-	case schema.TypeString, schema.TypeUUID, schema.TypeCIDR, schema.TypeInet, schema.TypeMacAddr,
-		schema.TypeStringArray, schema.TypeUUIDArray, schema.TypeCIDRArray, schema.TypeInetArray, schema.TypeMacAddrArray:
-		opts = append(opts, "type=BYTE_ARRAY", "convertedtype=UTF8")
-	case schema.TypeFloat:
-		opts = append(opts, "type=DOUBLE")
-	case schema.TypeInt, schema.TypeIntArray:
-		opts = append(opts, "type=INT64")
-	case schema.TypeByteArray:
-		opts = append(opts, "type=BYTE_ARRAY")
-	case schema.TypeBool:
-		opts = append(opts, "type=BOOLEAN")
-	default:
-		panic("unhandled type: " + col.Type.String())
-	}
-
-	switch col.Type {
-	case schema.TypeStringArray, schema.TypeIntArray, schema.TypeUUIDArray, schema.TypeCIDRArray, schema.TypeInetArray, schema.TypeMacAddrArray:
-		opts = append(opts, "repetitiontype=REPEATED")
-	default:
-		if col.CreationOptions.PrimaryKey || col.CreationOptions.IncrementalKey {
-			opts = append(opts, "repetitiontype=REQUIRED")
-		} else {
-			opts = append(opts, "repetitiontype=OPTIONAL")
-		}
-	}
-
-	return opts
 }

--- a/parquet/schema.go
+++ b/parquet/schema.go
@@ -25,8 +25,6 @@ func makeSchema(tableName string, cols schema.ColumnList) string {
 			tag = append(tag, "type=INT64", "convertedtype=TIMESTAMP_MILLIS")
 		case schema.TypeString, schema.TypeUUID, schema.TypeCIDR, schema.TypeInet, schema.TypeMacAddr:
 			tag = append(tag, "type=BYTE_ARRAY", "convertedtype=UTF8")
-		//case schema.TypeUUID:
-		//	tag = append(tag, "type=FIXED_LEN_BYTE_ARRAY", "length=22", "logicaltype=UUID")
 		case schema.TypeFloat:
 			tag = append(tag, "type=DOUBLE")
 		case schema.TypeInt:
@@ -37,14 +35,7 @@ func makeSchema(tableName string, cols schema.ColumnList) string {
 			tag = append(tag, "type=BOOLEAN")
 		case schema.TypeIntArray:
 			tag = append(tag, "type=INT64", "repetitiontype=REPEATED")
-		case schema.TypeStringArray /*schema.TypeUUIDArray,*/, schema.TypeCIDRArray, schema.TypeInetArray, schema.TypeMacAddrArray:
-			tag = append(tag, "type=LIST", "repetitiontype=OPTIONAL")
-			subFields = []*pschema.JSONSchemaItemType{
-				{
-					Tag: "name=element, type=BYTE_ARRAY, convertedtype=UTF8, repetitiontype=OPTIONAL",
-				},
-			}
-		case schema.TypeUUIDArray:
+		case schema.TypeStringArray, schema.TypeUUIDArray, schema.TypeCIDRArray, schema.TypeInetArray, schema.TypeMacAddrArray:
 			tag = append(tag, "type=LIST", "repetitiontype=OPTIONAL")
 			subFields = []*pschema.JSONSchemaItemType{
 				{

--- a/parquet/schema.go
+++ b/parquet/schema.go
@@ -10,8 +10,7 @@ import (
 
 func makeSchema(tableName string, cols schema.ColumnList) string {
 	s := pschema.JSONSchemaItemType{
-		//Tag: `name=` + tableName + `_root, repetitiontype=REQUIRED`,
-		Tag: `name=parquet_go_root, repetitiontype=REQUIRED`,
+		Tag: `name=` + tableName + `_root, repetitiontype=REQUIRED`,
 	}
 
 	for _, col := range cols {

--- a/parquet/schema.go
+++ b/parquet/schema.go
@@ -19,11 +19,9 @@ func makeSchema(tableName string, cols schema.ColumnList) string {
 		tag := []string{`name=` + col.Name}
 
 		switch col.Type {
-		case schema.TypeJSON:
-			tag = append(tag, "type=BYTE_ARRAY", "convertedtype=UTF8", "logicaltype=JSON")
 		case schema.TypeTimestamp:
 			tag = append(tag, "type=INT64", "convertedtype=TIMESTAMP_MILLIS")
-		case schema.TypeString, schema.TypeUUID, schema.TypeCIDR, schema.TypeInet, schema.TypeMacAddr:
+		case schema.TypeJSON, schema.TypeString, schema.TypeUUID, schema.TypeCIDR, schema.TypeInet, schema.TypeMacAddr:
 			tag = append(tag, "type=BYTE_ARRAY", "convertedtype=UTF8")
 		case schema.TypeFloat:
 			tag = append(tag, "type=DOUBLE")

--- a/parquet/transformer.go
+++ b/parquet/transformer.go
@@ -93,6 +93,9 @@ func (Transformer) TransformUUID(v *schema.UUID) any {
 		return nil
 	}
 	return v.String()
+	//bb := make([]byte, 16)
+	//copy(bb, v.Bytes[:])
+	//return bb
 }
 
 func (Transformer) TransformUUIDArray(v *schema.UUIDArray) any {
@@ -177,12 +180,19 @@ func (ReverseTransformer) ReverseTransformValues(table *schema.Table, values []a
 			if err := t.Set(v); err != nil {
 				return nil, fmt.Errorf("failed to convert value %v to type %s: %w", v, table.Columns[i].Type, err)
 			}
-			//res[i] = t
+			res[i] = t
 			continue
 		}
 
 		var err error
 		switch table.Columns[i].Type {
+		//case schema.TypeUUID:
+		//	b, err2 := base64.RawStdEncoding.DecodeString(v.(string))
+		//	if err2 != nil {
+		//		err = err2
+		//		break
+		//	}
+		//	err = t.Set(b)
 		case schema.TypeTimestamp:
 			err = t.Set(time.UnixMilli(v.(int64)))
 		default:

--- a/parquet/transformer.go
+++ b/parquet/transformer.go
@@ -177,6 +177,7 @@ func (ReverseTransformer) ReverseTransformValues(table *schema.Table, values []a
 			if err := t.Set(v); err != nil {
 				return nil, fmt.Errorf("failed to convert value %v to type %s: %w", v, table.Columns[i].Type, err)
 			}
+			//res[i] = t
 			continue
 		}
 

--- a/parquet/transformer.go
+++ b/parquet/transformer.go
@@ -93,9 +93,6 @@ func (Transformer) TransformUUID(v *schema.UUID) any {
 		return nil
 	}
 	return v.String()
-	//bb := make([]byte, 16)
-	//copy(bb, v.Bytes[:])
-	//return bb
 }
 
 func (Transformer) TransformUUIDArray(v *schema.UUIDArray) any {
@@ -186,13 +183,6 @@ func (ReverseTransformer) ReverseTransformValues(table *schema.Table, values []a
 
 		var err error
 		switch table.Columns[i].Type {
-		//case schema.TypeUUID:
-		//	b, err2 := base64.RawStdEncoding.DecodeString(v.(string))
-		//	if err2 != nil {
-		//		err = err2
-		//		break
-		//	}
-		//	err = t.Set(b)
 		case schema.TypeTimestamp:
 			err = t.Set(time.UnixMilli(v.(int64)))
 		default:

--- a/parquet/write.go
+++ b/parquet/write.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (*Client) WriteTableBatch(w io.Writer, table *schema.Table, resources [][]any) error {
-	pw, err := writer.NewJSONWriterFromWriter(makeSchema(table.Columns), w, 2)
+	pw, err := writer.NewJSONWriterFromWriter(makeSchema(table.Name, table.Columns), w, 2)
 	if err != nil {
 		return fmt.Errorf("can't create parquet writer: %w", err)
 	}


### PR DESCRIPTION
This PR fixes the array/slice handling in the Parquet filetype by slightly updating the Parquet schema definition.

It's possible to represent UUID types with the proper logical type but it just didn't work with Athena. Also had to do some weird things like defining the uuid as **22-byte** FIXED_LEN_BYTE_ARRAY (UUIDs are 16 bytes) but giving it a 16-byte Go slice (not a Go array) and Base64 decoders in reverse transformers etc... And all this didn't even work when it came to `UUIDArray`s... So I gave up on that for now.

JSON logicaltype seems to somewhat work with DuckDB but doesn't with Athena so I removed that as well.