### PR TITLE
chore: Replace deprecated `run.skip-dirs` with `issues.exclude-dirs` in lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,9 @@
 run:
   tests: true
   timeout: 10m
-  skip-dirs:
+issues:
+  exclude-dirs:
     - internal/pb
-
 linters-settings:
   errcheck:
     check-blank: false


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Part of https://github.com/cloudquery/cloudquery/issues/17455

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
