### PR TITLE
fix: Parquet premature closing

### DIFF
--- a/parquet/write.go
+++ b/parquet/write.go
@@ -30,7 +30,7 @@ func (c *Client) WriteHeader(w io.Writer, t *schema.Table) (ftypes.Handle, error
 	)
 	arrprops := pqarrow.DefaultWriterProps()
 	newSchema := convertSchema(t.ToArrowSchema())
-	fw, err := pqarrow.NewFileWriter(newSchema, w, props, arrprops)
+	fw, err := pqarrow.NewFileWriter(newSchema, &nopCloseWriter{Writer: w}, props, arrprops)
 	if err != nil {
 		return nil, err
 	}
@@ -159,3 +159,13 @@ func transformToString(arr arrow.Array) arrow.Array {
 
 	return builder.NewArray()
 }
+
+type nopCloseWriter struct {
+	io.Writer
+}
+
+func (w *nopCloseWriter) Close() error {
+	return nil
+}
+
+var _ io.WriteCloser = (*nopCloseWriter)(nil)

--- a/parquet/write.go
+++ b/parquet/write.go
@@ -164,7 +164,7 @@ type nopCloseWriter struct {
 	io.Writer
 }
 
-func (w *nopCloseWriter) Close() error {
+func (*nopCloseWriter) Close() error {
 	return nil
 }
 


### PR DESCRIPTION
Make sure `ParquetWriter` doesn't close our `io.Writer`: `WriteFooter()` shouldn't close the file.

https://github.com/apache/arrow-go/blob/v18.3.1/parquet/internal/utils/write_utils.go#L46
